### PR TITLE
Fix duplicate AssemblyInfo compile item in VB project

### DIFF
--- a/PgAce.App/PgAce.App.vbproj
+++ b/PgAce.App/PgAce.App.vbproj
@@ -12,7 +12,4 @@
     <PackageReference Include="DockPanelSuite" Version="3.0.4" />
     <PackageReference Include="ScintillaNET" Version="2.6.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="My Project\AssemblyInfo.vb" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- remove explicit compile include for `My Project/AssemblyInfo.vb` so the SDK's implicit compile items don't cause duplicates

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(403 Forbidden: unable to install dotnet-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_689217c94b3483288096e6a587e27edf