### PR TITLE
Resolve namespace conflicts and update Npgsql

### DIFF
--- a/PgAce.App/My Project/AssemblyInfo.vb
+++ b/PgAce.App/My Project/AssemblyInfo.vb
@@ -1,16 +1,7 @@
 Imports System.Reflection
 Imports System.Runtime.InteropServices
 
-<Assembly: AssemblyTitle("PgAce")>
 <Assembly: AssemblyDescription("Portable PostgreSQL client")>
-<Assembly: AssemblyConfiguration("")>
-<Assembly: AssemblyCompany("")>
-<Assembly: AssemblyProduct("PgAce")>
 <Assembly: AssemblyCopyright("Copyright (c) 2024 PgAce")>
-<Assembly: AssemblyTrademark("")>
-<Assembly: AssemblyCulture("")>
-
 <Assembly: ComVisible(False)>
 
-<Assembly: AssemblyVersion("0.1.0.0")>
-<Assembly: AssemblyFileVersion("0.1.0.0")>

--- a/PgAce.App/PgAce.App.vbproj
+++ b/PgAce.App/PgAce.App.vbproj
@@ -3,12 +3,12 @@
     <TargetFramework>net472</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <OutputType>WinExe</OutputType>
-    <RootNamespace>PgAce.App</RootNamespace>
+    <RootNamespace></RootNamespace>
     <AssemblyName>PgAce</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Npgsql" Version="4.1.0" />
+    <PackageReference Include="Npgsql" Version="6.0.8" />
     <PackageReference Include="DockPanelSuite" Version="3.0.4" />
     <PackageReference Include="ScintillaNET" Version="2.6.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- simplify assembly info to avoid duplicate attributes
- remove root namespace to allow PgAce.App namespaces
- upgrade Npgsql to address security advisory

## Testing
- `dotnet build PgAce.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689219201e108328adb33a066ccfb890