### PR TITLE
refactor: clarify DPAPI usage

### DIFF
--- a/PgAce.App/Services/EncryptionService.vb
+++ b/PgAce.App/Services/EncryptionService.vb
@@ -11,19 +11,23 @@ Namespace PgAce.App.Services
 
         Public Shared Function Protect(plaintext As String) As String
             If String.IsNullOrEmpty(plaintext) Then Return plaintext
-            Dim data = Encoding.UTF8.GetBytes(plaintext)
-            Dim protectedData = ProtectedData.Protect(data, Nothing, DataProtectionScope.CurrentUser)
+
+            Dim data As Byte() = Encoding.UTF8.GetBytes(plaintext)
+            Dim protectedData As Byte() = ProtectedData.Protect(data, Nothing, DataProtectionScope.CurrentUser)
+
             Return Prefix & Convert.ToBase64String(protectedData)
         End Function
 
         Public Shared Function Unprotect(cipher As String) As String
             If String.IsNullOrEmpty(cipher) Then Return cipher
             If Not cipher.StartsWith(Prefix) Then Return cipher
-            Dim base64 = cipher.Substring(Prefix.Length)
-            Dim protectedData = Convert.FromBase64String(base64)
+
+            Dim base64 As String = cipher.Substring(Prefix.Length)
+            Dim protectedData As Byte() = Convert.FromBase64String(base64)
+
             Try
-                Dim data = ProtectedData.Unprotect(protectedData, Nothing, DataProtectionScope.CurrentUser)
-                Return Encoding.UTF8.GetString(data)
+                Dim unprotectedData As Byte() = ProtectedData.Unprotect(protectedData, Nothing, DataProtectionScope.CurrentUser)
+                Return Encoding.UTF8.GetString(unprotectedData)
             Catch ex As CryptographicException
                 Return String.Empty ' failed to decrypt
             End Try


### PR DESCRIPTION
## Summary
- clarify DPAPI protect/unprotect by explicitly typing byte arrays
- rename variables for clearer separation of protected vs unprotected data

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68921a8f1cf083289d8c71c857babda8