### PR TITLE
Fix project file by using base .NET SDK

### DIFF
--- a/PgAce.App/PgAce.App.csproj
+++ b/PgAce.App/PgAce.App.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net472</TargetFramework>


### PR DESCRIPTION
## Summary
- replace WindowsDesktop SDK with base Microsoft.NET.Sdk for PgAce.App

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689296b9e1e88328b3412d5e1a641873